### PR TITLE
Add QoS in cmd_vel subscriber

### DIFF
--- a/scout_base/include/scout_base/scout_messenger.hpp
+++ b/scout_base/include/scout_base/scout_messenger.hpp
@@ -54,7 +54,7 @@ class ScoutMessenger {
 
         // cmd subscriber
     motion_cmd_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
-            "/cmd_vel", 5,
+            "/cmd_vel", rclcpp::SensorDataQoS(),
             std::bind(&ScoutMessenger::TwistCmdCallback, this,
                       std::placeholders::_1));
     light_cmd_sub_ = node_->create_subscription<scout_msgs::msg::ScoutLightCmd>(


### PR DESCRIPTION
#### **Overview**

This PR updates the _cmd_vel_ subscriber's Quality of Service to best effort. This change is due to the integration with the HMI, improving teleoperation communication.

#### **Use the following settings in the overrides file for docker testing**

- _overrides.yaml_

  ```yaml
    overrides:
      - scout_ros2:
        branch: feature/cmd_qos
  ```

- _manifest_

  ```yaml
    package_sets:
      - github: Brazilian-Institute-of-Robotics/bir.subot-package_set
        private: true
    layout:
      - scout_ros2
  ```

#### **What was added/changed in this update**

- [Add best_effort QoS in cmd_vel subscriber](https://github.com/Brazilian-Institute-of-Robotics/scout_ros2/commit/e093d8707e2a6c7d5a474a3772f1788b6ffe340d)

#### **Depends On:**

- N/A

#### **Related Issues:**

- N/A

#### **Notes:**

- N/A